### PR TITLE
detached dev work to dev

### DIFF
--- a/ugit/base.py
+++ b/ugit/base.py
@@ -4,6 +4,7 @@ import os
 import string
 
 from collections import namedtuple
+from typing import Generator, Any
 
 from . import data
 
@@ -117,6 +118,31 @@ def get_commit(oid: str):
 
     message = '\n'.join(lines)
     return Commit(tree=tree, parent=parent, message=message)
+
+def iter_commits_and_parents(oids) -> Generator[Any]:
+    """
+    Printing all OIDs reachable from references. This is a generator that returns all commits that it can reach from a given set of OIDs.
+
+    Following the parents of tag1 or by following the parents of tag2 we can reach the first commit.
+
+    o<----o<----o<----o<----@<----@<----@
+    ^                  \                ^
+    first commit        -<--$<----$     refs/tags/tag1
+                                    ^
+                                    refs/tags/tag2
+    """
+    oids = set(oids)
+    visited = set()
+
+    while oids:
+        oid = oids.pop()
+        if not oid or oid in visited:
+            continue
+        visited.add(oid)
+        yield oid
+
+        commit = get_commit(oid)
+        oids.add(commit.parent)
 
 def get_oid(name):
     if name == '@': 

--- a/ugit/base.py
+++ b/ugit/base.py
@@ -1,6 +1,7 @@
 import itertools
 import operator
 import os
+import string
 
 from collections import namedtuple
 
@@ -118,7 +119,27 @@ def get_commit(oid: str):
     return Commit(tree=tree, parent=parent, message=message)
 
 def get_oid(name):
-    return data.get_ref(name) or name
+    if name == '@': 
+        name = 'HEAD'
+
+    # Name is ref
+    refs_to_try = [
+        f'{name}',
+        f'refs/{name}',
+        f'refs/tags/{name}',
+        f'refs/heads/{name}'
+    ]
+
+    for ref in refs_to_try:
+        if data.get_ref(ref):
+            return data.get_ref(ref)
+    
+    # Name is SHA1
+    is_hex = all(c in string.hexdigits for c in name)
+    if len(name) == 40 and is_hex:
+        return name
+    
+    assert False, f'Unknown name {name}'
 
 def is_ignored(path) -> bool:
     """

--- a/ugit/cli.py
+++ b/ugit/cli.py
@@ -67,6 +67,9 @@ def parse_args():
     tag_parser.add_argument('name')
     tag_parser.add_argument('oid', default='@', type=oid, nargs='?')
 
+    k_parser = commands.add_parser('k')
+    k_parser.set_defaults(func=k)
+
     return parser.parse_args()
 
 def init(args) -> None:
@@ -108,3 +111,27 @@ def checkout(args):
 
 def tag(args):
     base.create_tag(args.name, args.oid)
+
+def k(args) -> None:
+    """
+    Similar function to gitk which is a graphical visualization tool for Git.
+
+    Usage: ugit k
+
+    reference: (#k: Print refs)
+    """
+    oids = set()
+    # iter_refs is a generator iterating on all available  refs
+    # it will return HEAD from the ugit root directory
+    # and everything under .ugit/refs.
+    for refName, ref in data.iter_refs():
+        print(refName, ref)
+        oids.add(ref)
+
+    for oid in base.iter_commits_and_parents(oids):
+        commit = base.get_commit(oid)
+        print(oid)
+        if commit.parent:
+            print('Parent', commit.parent)
+            
+    # TODO visualise refs

--- a/ugit/cli.py
+++ b/ugit/cli.py
@@ -56,7 +56,7 @@ def parse_args():
 
     log_parser = commands.add_parser('log')
     log_parser.set_defaults(func=log)
-    log_parser.add_argument('oid', type=oid, nargs='?')
+    log_parser.add_argument('oid', default='@', type=oid, nargs='?')
 
     checkout_parser = commands.add_parser('checkout')
     checkout_parser.set_defaults(func=checkout)
@@ -65,7 +65,7 @@ def parse_args():
     tag_parser = commands.add_parser('tag')
     tag_parser.set_defaults(func=tag)
     tag_parser.add_argument('name')
-    tag_parser.add_argument('oid', type=oid, nargs='?')
+    tag_parser.add_argument('oid', default='@', type=oid, nargs='?')
 
     return parser.parse_args()
 
@@ -93,8 +93,7 @@ def commit(args):
     print(base.commit(args.message))
 
 def log(args):
-    # oid = args.oid or data.get_HEAD()
-    oid = args.oid or data.get_ref('HEAD')
+    oid = args.oid
     while oid:
         commit = base.get_commit(oid)
 
@@ -108,6 +107,4 @@ def checkout(args):
     base.checkout(args.oid)
 
 def tag(args):
-    # oid = args.oid or data.get_HEAD()
-    oid = args.oid or data.get_ref('HEAD')
-    base.create_tag(args.name, oid)
+    base.create_tag(args.name, args.oid)

--- a/ugit/data.py
+++ b/ugit/data.py
@@ -1,3 +1,4 @@
+from typing import Generator, Any
 import hashlib
 import os
 
@@ -24,6 +25,18 @@ def get_ref(ref) -> str | None:
     if os.path.isfile(ref_path):
         with open(ref_path) as f:
             return f.read().strip()
+        
+def iter_refs() -> Generator[Any, Any, Any]:
+    # iter_refs is a generator iterating on all available refs
+    # it will return HEAD from the ugit root directory
+    # and everything under .ugit/refs.
+    # _ here is a throwoaway variable, only root and filenames are required
+    refs = ['HEAD']
+    for root, _, filenames in os.walk(f'{GIT_DIR}/refs/'):
+        root = os.path.relpath(root, GIT_DIR)
+        refs.extend(f'{root}/{name}' for name in filenames)
+    for refname in refs:
+        yield refname, get_ref(refname)
 
 def hash_object(data, type_='blob') -> str:
     """


### PR DESCRIPTION
I was detached from `HEAD` when pull this repo onto my WSL environment. I went through the hussle and my issue relied in type of token. I used `token (classic)` as a solution as Git now doesn't support passwords as per of their authentication methods.

Writing a `k` part of the `ugit` tutorial. It is suppose to be a visualisation tool.